### PR TITLE
Fix scopes and https endpoint (DB-122)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ARG UID=1000
 ARG GID=1000
 
 ENV ASPNETCORE_ENVIRONMENT=Development
+ENV DOTNET_URLS=https://+:5000;https://+:5001
 
 RUN mkdir /etc/idsrv4
 

--- a/src/IdentityServer/Program.cs
+++ b/src/IdentityServer/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using IdentityServer;
@@ -51,6 +51,7 @@ builder.Services
 	.AddTestUsers(TestUsers.FromFile())
 	.AddInMemoryIdentityResources(builder.Configuration.GetSection("IdentityResources"))
 	.AddInMemoryApiResources(builder.Configuration.GetSection("ApiResources"))
+	.AddInMemoryApiScopes(builder.Configuration.GetSection("ApiScopes"))
 	.AddInMemoryClients(builder.Configuration.GetSection("Clients"))
 	.AddDeveloperSigningCredential().Services
 	.AddAuthentication()


### PR DESCRIPTION
Fixed: HTTPS endpoint not working because of missing `DOTNET_URLS`.
Fixed: Scopes were not configured properly.

After this PR the container will work again as before the upgrade to `IdentityServer4 4.1.2` without requiring `DOTNET_URLS`, it can still be overridden. The configuration of `scopes` was also changed in `4.1.2`.